### PR TITLE
expose opcodes for use as a library

### DIFF
--- a/FFXIVOpcodes/Ipcs.cs
+++ b/FFXIVOpcodes/Ipcs.cs
@@ -34,7 +34,7 @@ namespace FFXIVOpcodes.Global
     /**
     * Server IPC Zone Type Codes.
     */
-    enum ServerZoneIpcType : ushort
+    public enum ServerZoneIpcType : ushort
     {
         PlayerSetup = 0x0312, // Updated 6.11
         UpdateHpMpTp = 0x028B, // Updated 6.11


### PR DESCRIPTION
I want to use FFXIVOpcodes as a library instead of importing a .json file and parsing it manually. This allows me to do that. Could also do the same for the other regions.