### PR TITLE
Added island workshop supply/demand opcode

### DIFF
--- a/FFXIVOpcodes/Ipcs.cs
+++ b/FFXIVOpcodes/Ipcs.cs
@@ -102,6 +102,7 @@ namespace FFXIVOpcodes.Global
         EventPlay128 = 0x129, // Updated for 6.2 Hotfix
         EventPlay255 = 0x2cd, // Updated for 6.2 Hotfix
         EnvironmentControl = 0x24A, // Updated for 6.2 Hotfix
+        IslandWorkshopSupplyDemand = 0x1D3, //Updated 6.2 Hotfix
         Logout = 0x0230 // Updated 6.2 hotfix
     };
 


### PR DESCRIPTION
Have been using this one in some of my own tools, and figured I'd contribute it upstream if it's welcome.

Reference info in case someone references this and has use of it:
64 byte payload
byte 0: current popularity schedule index (MJICraftworksPopularity)
byte 1: predicted popularity schedule index
bytes 2 to 63: correspond to indices in mjicraftworksobject
    first value is always 0, doesnt correspond to an object, as 0 doesnt correspond to anything in mjicraftworksobject
each byte is split into 2 nibbles
high order nibble: supply values of 0,1,2,3,4 indicating nonexistent, insufficient, sufficient, surplus,overflowing
low order nibble: demand shift values of 0,1,2,3,4 indicate skyrocketing, increasing, none, decreasing, plummeting 